### PR TITLE
add build.rs outputs and link directive 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libdeflater"
 version = "0.2.0"
 authors = ["Adam Kewley <contact@adamkewley.com>"]
+links = "libdeflate"
 edition = "2018"
 license = "Apache-2.0"
 readme = "README.md"

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ fn main() {
         .include("libdeflate/common/")
         .warnings(false)
         .out_dir(dst.join("lib"))
-        .compile("libdeflate");
+        .compile("libdeflate.a");
 
         let src = env::current_dir().unwrap().join("libdeflate");
         let include = dst.join("include");

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,12 @@
 extern crate cc;
+use std::env;
+use std::path::PathBuf;
+use std::fs;
 
 fn main() {
+
+    let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
     cc::Build::new()
         .file("libdeflate/lib/aligned_malloc.c")
         .file("libdeflate/lib/deflate_decompress.c")
@@ -17,5 +23,13 @@ fn main() {
         .include("libdeflate/lib/")
         .include("libdeflate/common/")
         .warnings(false)
+        .out_dir(dst.join("lib"))
         .compile("libdeflate");
+
+        let src = env::current_dir().unwrap().join("libdeflate");
+        let include = dst.join("include");
+        fs::create_dir_all(&include).unwrap();
+        fs::copy(src.join("libdeflate.h"), dst.join("include/libdeflate.h")).unwrap();
+        println!("cargo:root={}", dst.display());
+        println!("cargo:include={}", dst.join("include").display());
 }


### PR DESCRIPTION
This allows downstream C code to link to libdeflate provided by this crate. (eg. rust-htslib)