### PR TITLE
Add freestanding build support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,14 @@ flate2 = "1.0.11"
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[features]
+# Makes libdeflate use Rust's allocator instead of the libc one.
+# This is useful when Rust is preconfigured to a custom global allocator
+# (e.g. pool-based, or a tracking one, or something else entirely).
+use_rust_alloc = []
+# Builds libdeflate in a freestanding mode (no reliance on libc).
+# This is useful for targets that don't have a C stdlib (e.g. wasm32-unknown-unknown).
+freestanding = ["libdeflate-sys/freestanding", "use_rust_alloc"]
+
+[workspace]

--- a/README.md
+++ b/README.md
@@ -144,3 +144,14 @@ xargs.1         4            1.7        19             11
 
 - Corpus entries were compressed with `flate2` at default compression
   level
+
+### Compile-time features
+
+You can enable the following features to customise the build:
+ - `use_rust_alloc`: Makes libdeflate use Rust's allocator instead of the libc one.
+   This is useful when Rust is preconfigured to use a
+   [custom global allocator](https://doc.rust-lang.org/edition-guide/rust-2018/platform-and-target-support/global-allocators.html)
+   (e.g. pool-based, or a tracking one, or something else entirely).
+ - `freestanding`: Builds libdeflate in a freestanding mode (no reliance on libc).
+   This is useful for targets that don't have a C stdlib (e.g. `wasm32-unknown-unknown`)
+   as otherwise they would fail to compile. Implies `use_rust_alloc`.

--- a/libdeflate-sys/Cargo.toml
+++ b/libdeflate-sys/Cargo.toml
@@ -18,3 +18,6 @@ build = "build.rs"
 
 [build-dependencies]
 cc = "1.0"
+
+[features]
+freestanding = []

--- a/libdeflate-sys/build.rs
+++ b/libdeflate-sys/build.rs
@@ -1,35 +1,43 @@
-extern crate cc;
 use std::env;
-use std::path::PathBuf;
 use std::fs;
+use std::path::{Path, PathBuf};
 
 fn main() {
-
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-    cc::Build::new()
-        .file("libdeflate/lib/aligned_malloc.c")
-        .file("libdeflate/lib/deflate_decompress.c")
-        .file("libdeflate/lib/arm/cpu_features.c")
-        .file("libdeflate/lib/x86/cpu_features.c")
-        .file("libdeflate/lib/deflate_compress.c")
-        .file("libdeflate/lib/adler32.c")
-        .file("libdeflate/lib/zlib_decompress.c")
-        .file("libdeflate/lib/zlib_compress.c")
-        .file("libdeflate/lib/crc32.c")
-        .file("libdeflate/lib/gzip_decompress.c")
-        .file("libdeflate/lib/gzip_compress.c")
-        .include("libdeflate/")
-        .include("libdeflate/lib/")
-        .include("libdeflate/common/")
-        .warnings(false)
-        .out_dir(dst.join("lib"))
-        .compile("libdeflate.a");
+    let mut build = cc::Build::new();
 
-        let src = env::current_dir().unwrap().join("libdeflate");
-        let include = dst.join("include");
-        fs::create_dir_all(&include).unwrap();
-        fs::copy(src.join("libdeflate.h"), dst.join("include/libdeflate.h")).unwrap();
-        println!("cargo:root={}", dst.display());
-        println!("cargo:include={}", dst.join("include").display());
+    build
+        .files(&[
+            "libdeflate/lib/arm/cpu_features.c",
+            "libdeflate/lib/x86/cpu_features.c",
+            "libdeflate/lib/adler32.c",
+            "libdeflate/lib/crc32.c",
+            "libdeflate/lib/deflate_compress.c",
+            "libdeflate/lib/deflate_decompress.c",
+            "libdeflate/lib/gzip_compress.c",
+            "libdeflate/lib/gzip_decompress.c",
+            "libdeflate/lib/utils.c",
+            "libdeflate/lib/zlib_compress.c",
+            "libdeflate/lib/zlib_decompress.c",
+        ])
+        .include("libdeflate")
+        .warnings(false)
+        .out_dir(dst.join("lib"));
+
+    if cfg!(feature = "freestanding") && !build.get_compiler().is_like_msvc() {
+        build
+            .flag("-ffreestanding")
+            .flag("-nostdlib")
+            .define("FREESTANDING", None);
+    }
+
+    build.compile("deflate");
+
+    let src = Path::new("libdeflate");
+    let include = dst.join("include");
+    fs::create_dir_all(&include).unwrap();
+    fs::copy(src.join("libdeflate.h"), &include.join("libdeflate.h")).unwrap();
+    println!("cargo:root={}", dst.display());
+    println!("cargo:include={}", include.display());
 }

--- a/libdeflate-sys/src/lib.rs
+++ b/libdeflate-sys/src/lib.rs
@@ -78,6 +78,9 @@ extern "C" {
     pub fn libdeflate_adler32(adler32: u32,
                               buffer: *const ::std::os::raw::c_void,
                               len: usize) -> u32;
+
+    pub fn libdeflate_set_memory_allocator(malloc_func: unsafe extern "C" fn(size: usize) -> *mut ::std::os::raw::c_void,
+                                           free_func: unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void));
 }
 
 // Basic tests for Rust-to-C bindings. These tests are just for quick

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,14 @@ use libdeflate_sys::{libdeflate_decompressor,
                             libdeflate_free_compressor,
                             libdeflate_crc32};
 
+#[cfg(feature = "use_rust_alloc")]
+mod malloc_wrapper;
+#[cfg(feature = "use_rust_alloc")]
+use malloc_wrapper::init_allocator;
+
+#[cfg(not(feature = "use_rust_alloc"))]
+fn init_allocator() {}
+
 /// A `libdeflate` decompressor that can inflate DEFLATE, zlib, or
 /// gzip data.
 pub struct Decompressor {
@@ -112,6 +120,7 @@ impl Decompressor {
     /// Returns a newly constructed instance of a `Decompressor`.
     pub fn new() -> Decompressor {
         unsafe {
+            init_allocator();
             let ptr = libdeflate_alloc_decompressor();
             if !ptr.is_null() {
                 Decompressor{ p: ptr }
@@ -131,6 +140,7 @@ impl Decompressor {
                            gz_data: &[u8],
                            out: &mut [u8]) -> DecompressionResult<usize> {
         unsafe {
+            init_allocator();
             let mut out_nbytes = 0;
             let in_ptr = gz_data.as_ptr() as *const std::ffi::c_void;
             let out_ptr = out.as_mut_ptr() as *mut std::ffi::c_void;
@@ -168,6 +178,7 @@ impl Decompressor {
                            zlib_data: &[u8],
                            out: &mut [u8]) -> DecompressionResult<usize> {
         unsafe {
+            init_allocator();
             let mut out_nbytes = 0;
             let in_ptr = zlib_data.as_ptr() as *const std::ffi::c_void;
             let out_ptr = out.as_mut_ptr() as *mut std::ffi::c_void;
@@ -206,6 +217,7 @@ impl Decompressor {
                               deflate_data: &[u8],
                               out: &mut [u8]) -> DecompressionResult<usize> {
         unsafe {
+            init_allocator();
             let mut out_nbytes = 0;
             let in_ptr = deflate_data.as_ptr() as *const std::ffi::c_void;
             let out_ptr = out.as_mut_ptr() as *mut std::ffi::c_void;
@@ -350,6 +362,7 @@ impl Compressor {
     /// [`CompressionLvl`](struct.CompressionLvl.html)
     pub fn new(lvl: CompressionLvl) -> Compressor {
         unsafe {
+            init_allocator();
             let ptr = libdeflate_alloc_compressor(lvl.0);
             if !ptr.is_null() {
                 Compressor{ p: ptr }
@@ -378,6 +391,7 @@ impl Compressor {
                             in_raw_data: &[u8],
                             out_deflate_data: &mut [u8]) -> CompressionResult<usize> {
         unsafe {
+            init_allocator();
             let in_ptr = in_raw_data.as_ptr() as *const std::ffi::c_void;
             let out_ptr = out_deflate_data.as_mut_ptr() as *mut std::ffi::c_void;
 
@@ -414,6 +428,7 @@ impl Compressor {
                          in_raw_data: &[u8],
                          out_zlib_data: &mut [u8]) -> CompressionResult<usize> {
         unsafe {
+            init_allocator();
             let in_ptr = in_raw_data.as_ptr() as *const std::ffi::c_void;
             let out_ptr = out_zlib_data.as_mut_ptr() as *mut std::ffi::c_void;
 
@@ -450,6 +465,7 @@ impl Compressor {
                          in_raw_data: &[u8],
                          out_gzip_data: &mut [u8]) -> CompressionResult<usize> {
         unsafe {
+            init_allocator();
             let in_ptr = in_raw_data.as_ptr() as *const std::ffi::c_void;
             let out_ptr = out_gzip_data.as_mut_ptr() as *mut std::ffi::c_void;
 

--- a/src/malloc_wrapper.rs
+++ b/src/malloc_wrapper.rs
@@ -1,0 +1,49 @@
+//! This is a module that provides `malloc` and `free` for `libdeflate`.
+//! These implementations are compatible with the standard signatures
+//! but use Rust allocator instead of including libc one as well.
+//!
+//! Rust allocator APIs requires passing size and alignment to the
+//! `dealloc` function. This is different from C API, which only
+//! expects a pointer in `free` and expects allocators to take care of
+//! storing any necessary information elsewhere.
+//!
+//! In order to simulate C API, we allocate a `size_and_data_ptr`
+//! of size `sizeof(usize) + size` where `size` is the requested number
+//! of bytes. Then, we store `size` at the beginning of the allocated
+//! chunk (within those `sizeof(usize)` bytes) and return
+//! `data_ptr = size_and_data_ptr + sizeof(usize)` to the calleer:
+//!
+//! [`size`][...actual data]
+//! -^------------------ `size_and_data_ptr`
+//! ---------^---------- `data_ptr`
+//!
+//! Then, in `free`, the caller gives us `data_ptr`. We can subtract
+//! `sizeof(usize)` back and get the original `size_and_data_ptr`.
+//! At this point we can read `size` back and call the Rust `dealloc`
+//! for the whole allocated chunk.
+
+use libdeflate_sys::libdeflate_set_memory_allocator;
+use std::alloc::*;
+use std::ffi::c_void;
+use std::mem::{align_of, size_of};
+
+unsafe fn layout_for(size: usize) -> Layout {
+    Layout::from_size_align_unchecked(size_of::<usize>() + size, align_of::<usize>())
+}
+
+unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
+    let size_and_data_ptr = alloc(layout_for(size));
+    *(size_and_data_ptr as *mut usize) = size;
+    size_and_data_ptr.add(size_of::<usize>()) as _
+}
+
+unsafe extern "C" fn free(data_ptr: *mut c_void) {
+    let size_and_data_ptr = data_ptr.sub(size_of::<usize>());
+    let size = *(size_and_data_ptr as *const usize);
+    dealloc(size_and_data_ptr as _, layout_for(size))
+}
+
+pub unsafe fn init_allocator() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| libdeflate_set_memory_allocator(malloc, free))
+}


### PR DESCRIPTION
Following https://github.com/ebiggers/libdeflate/issues/62, upstream has recently added support for freestanding builds and custom allocators.

This is particularly useful for targets like wasm32-unknown-unknown that don't have a C standard library and where libdeflate & libdeflater would previously fail to compile without hacks.

I've updated to the latest libdeflate, added allocation routines that proxy calls to the Rust's global allocator, as well as added corresponding features for `use_rust_alloc` and `freestanding` to the crates Cargo.toml.

By default those features are set to off, since wrapping Rust's allocator instead of using libc one directly adds some minor overhead on targets that don't need it.