### PR TITLE
Added 'Send' trait to Decompressor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ fn init_allocator() {}
 pub struct Decompressor {
     p: *mut libdeflate_decompressor,
 }
+unsafe impl Send for Decompressor {}
 
 /// An error that may be returned by one of the
 /// [`Decompressor`](struct.Decompressor.html)'s `decompress_*`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,6 +355,7 @@ type CompressionResult<T> = std::result::Result<T, CompressionError>;
 pub struct Compressor {
     p: *mut libdeflate_compressor,
 }
+unsafe impl Send for Compressor {}
 
 impl Compressor {
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -95,8 +95,9 @@ fn read_fixture_deflate() -> Vec<u8> {
 
 #[test]
 fn test_can_send_decompressor_to_another_thread() {
-    // note: this is a compile-time test: it just ensures that
-    // Decompressor can be sent between threads easily
+    // note: this is a compile-time test: it just ensures that a
+    // `Decompressor` can be sent between threads easily (i.e. that
+    // `Decompressor` implements `Send`)
 
     let mut decompressor = Decompressor::new();
     let t = thread::spawn(move || {
@@ -111,8 +112,9 @@ fn test_can_send_decompressor_to_another_thread() {
 
 #[test]
 fn test_can_send_compressor_to_another_thread() {
-    // note: this is a compile-time test: it just ensures that
-    // Decompressor can be sent between threads easily
+    // note: this is a compile-time test: it just ensures that a
+    // Compressor can be sent between threads easily (i.e.  that
+    // `Compressor` implements `Send`)
 
     let mut compressor = Compressor::new(CompressionLvl::default());
     let t = thread::spawn(move || {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,6 +3,7 @@ extern crate libdeflater;
 use std::fs::File;
 use std::io::Read;
 use std::vec::Vec;
+use std::thread;
 use libdeflater::{Compressor, CompressionLvl, CompressionError, Decompressor, DecompressionError, CompressionLvlError};
 use flate2;
 
@@ -92,6 +93,21 @@ fn read_fixture_deflate() -> Vec<u8> {
     read_fixture("tests/hello.deflate")
 }
 
+#[test]
+fn test_can_send_decompressor_to_another_thread() {
+    // note: this is a compile-time test: it just ensures that
+    // Decompressor can be sent between threads easily
+
+    let mut decompressor = Decompressor::new();
+    let t = thread::spawn(move || {
+        let content = read_fixture_gz();
+        let mut decompressed = Vec::new();
+        decompressed.resize(fixture_content_size(), 0);
+
+        decompressor.gzip_decompress(&content, &mut decompressed).unwrap();
+    });
+    t.join().unwrap()
+}
 
 // gz decompression
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -109,6 +109,23 @@ fn test_can_send_decompressor_to_another_thread() {
     t.join().unwrap()
 }
 
+#[test]
+fn test_can_send_compressor_to_another_thread() {
+    // note: this is a compile-time test: it just ensures that
+    // Decompressor can be sent between threads easily
+
+    let mut compressor = Compressor::new(CompressionLvl::default());
+    let t = thread::spawn(move || {
+        let in_data = read_fixture_content();
+        let mut out_data = Vec::new();
+        let out_max_sz = compressor.deflate_compress_bound(in_data.len());
+        out_data.resize(out_max_sz, 0);
+
+        compressor.deflate_compress(&in_data, &mut out_data).unwrap();
+    });
+    t.join().unwrap()
+}
+
 // gz decompression
 
 #[test]


### PR DESCRIPTION
From: https://github.com/adamkewley/libdeflater/issues/6

@rakshith-ravi @IzumiRaine pointed out that the `Decompressor` is not `Send`, which makes using the library annoying in an async/multithreaded context. This PR adds the `Send` trait, plus basic compile-time tests to ensure the behavior.

I manually tested that double-drops do not occur. They do not, because once the decompressor is moved into another thread that thread is then responsible for calling `.drop`. The reason I was confused by that is because I've mostly been writing C++ for the last few months, where the destruction of temporaries has to be handled manually (e.g. in C++, the moved-from decompressor would have to null its pointer, and the `Drop` trait would only call the libdeflate deallocator if non-null: this is a specific C++-ism and doesn't apply to Rust).