### PR TITLE
Implemented std::error::Error for DecompressionError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@
 //! [`zlib_compress_bound`]: struct.Compressor.html#method.zlib_compress_bound
 //! [`gzip_compress_bound`]: struct.Compressor.html#method.gzip_compress_bound
 
+use std::error::Error;
+use std::fmt;
 use libdeflate_sys::{libdeflate_decompressor,
                             libdeflate_alloc_decompressor,
                             libdeflate_free_decompressor,
@@ -109,6 +111,21 @@ pub enum DecompressionError {
     /// The provided output buffer is not large enough to accomodate
     /// the decompressed data.
     InsufficientSpace,
+}
+
+impl fmt::Display for DecompressionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            DecompressionError::BadData => write!(f, "BadData: the data provided to a libdeflater *_decompress function call was invalid in some way (e.g. bad magic numbers, bad checksum)"),
+            DecompressionError::InsufficientSpace => write!(f, "InsufficientSpace: a buffer provided to a libdeflater *_decompress function call was too small to accommodate the decompressed data")
+        }
+    }
+}
+
+impl Error for DecompressionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self)
+    }
 }
 
 /// A result returned by decompression methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,17 +117,13 @@ pub enum DecompressionError {
 impl fmt::Display for DecompressionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
-            DecompressionError::BadData => write!(f, "BadData: the data provided to a libdeflater *_decompress function call was invalid in some way (e.g. bad magic numbers, bad checksum)"),
-            DecompressionError::InsufficientSpace => write!(f, "InsufficientSpace: a buffer provided to a libdeflater *_decompress function call was too small to accommodate the decompressed data")
+            DecompressionError::BadData => write!(f, "the data provided to a libdeflater *_decompress function call was invalid in some way (e.g. bad magic numbers, bad checksum)"),
+            DecompressionError::InsufficientSpace => write!(f, "a buffer provided to a libdeflater *_decompress function call was too small to accommodate the decompressed data")
         }
     }
 }
 
-impl Error for DecompressionError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(self)
-    }
-}
+impl Error for DecompressionError {}
 
 /// A result returned by decompression methods
 type DecompressionResult<T> = std::result::Result<T, DecompressionError>;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,6 +3,7 @@ extern crate libdeflater;
 use std::fs::File;
 use std::io::Read;
 use std::vec::Vec;
+use std::error::Error;
 use libdeflater::{Compressor, CompressionLvl, CompressionError, Decompressor, DecompressionError, CompressionLvlError};
 use flate2;
 
@@ -90,6 +91,12 @@ fn read_fixture_zlib_with_bad_adler32_checksum() -> Vec<u8> {
 
 fn read_fixture_deflate() -> Vec<u8> {
     read_fixture("tests/hello.deflate")
+}
+
+#[test]
+fn test_decompression_error_derives_error() {
+    let bd = DecompressionError::BadData;
+    let _e = (&bd) as &(dyn Error);
 }
 
 


### PR DESCRIPTION
Relates to: https://github.com/adamkewley/libdeflater/issues/7

@joshtriplett noticed that `DecompressionError` does not implement `std::error::Error`. Big oversight by me. This PR adds that functionality.

@joshtriplett , if you're around, could you quickly check the diff for this? I'll go ahead and merge it but the error messages might benefit from a touch-up in a later commit. I figure it's best to ship *something* right now that fixes this oversight--after all, it's a non-breaking addition--and I'm happy to clean up the error messages later.