### PR TITLE
[feature] Add conversion from level into inner type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,18 @@ impl Iterator for CompressionLvlIter {
     }
 }
 
+impl From<CompressionLvl> for i32 {
+    fn from(level: CompressionLvl) -> Self {
+        level.0
+    }
+}
+
+impl From<&CompressionLvl> for i32 {
+    fn from(level: &CompressionLvl) -> Self {
+        level.0
+    }
+}
+
 /// An error that may be returned when calling one of the
 /// [`Compressor`](struct.Compressor.html)'s `compress_*` methods.
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
This just allows for converting the [`CompressionLvl`] into an `i32`, which is useful for downstream libs that abstract over multiple compression formats. 