### PR TITLE
Adler32 Struct/methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ libdeflate-sys = { version = "0.12.0", path = "libdeflate-sys" }
 [dev-dependencies]
 criterion = "0.3"
 flate2 = "1.0.11"
+adler32 = "1.2.0"
 
 [[bench]]
 name = "benchmarks"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -769,7 +769,7 @@ fn test_use_adler32_reader_to_compute_adler32_of_fixture_returns_same_adler32_as
 
     let input_data = read_fixture_content();
 
-    let flate2_adler32 = {
+    let crate_adler32 = {
         let mut adler32 = adler32::RollingAdler32::new();
         adler32.update_buffer(&input_data);
         adler32.update_buffer(&input_data);
@@ -783,7 +783,7 @@ fn test_use_adler32_reader_to_compute_adler32_of_fixture_returns_same_adler32_as
         adler32.sum()
     };
 
-    assert_eq!(flate2_adler32, libdeflate_adler32);
+    assert_eq!(crate_adler32, libdeflate_adler32);
 }
 
 #[test]
@@ -793,7 +793,7 @@ fn test_use_adler32_convenience_method_returns_same_adler32_as_adler32_crate() {
 
     let input_data = read_fixture_content();
 
-    let flate2_adler32 = {
+    let crate_adler32 = {
         let mut adler32 = adler32::RollingAdler32::new();
         adler32.update_buffer(&input_data);
         adler32.hash()
@@ -801,5 +801,5 @@ fn test_use_adler32_convenience_method_returns_same_adler32_as_adler32_crate() {
 
     let libdeflate_adler32 = libdeflater::adler32(&input_data);
 
-    assert_eq!(flate2_adler32, libdeflate_adler32);
+    assert_eq!(crate_adler32, libdeflate_adler32);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -759,3 +759,47 @@ fn test_use_crc32_convenience_method_returns_same_crc32_as_flate2() {
 
     assert_eq!(flate2_crc32, libdeflate_crc32);
 }
+
+// adler32
+#[test]
+fn test_use_adler32_reader_to_compute_adler32_of_fixture_returns_same_adler32_as_adler32_crate(
+) {
+    // This assumes that adler32 crate implementation returns a
+    // correct value, which is a pretty safe assumption.
+
+    let input_data = read_fixture_content();
+
+    let flate2_adler32 = {
+        let mut adler32 = adler32::RollingAdler32::new();
+        adler32.update_buffer(&input_data);
+        adler32.update_buffer(&input_data);
+        adler32.hash()
+    };
+
+    let libdeflate_adler32 = {
+        let mut adler32 = libdeflater::Adler32::new();
+        adler32.update(&input_data);
+        adler32.update(&input_data);
+        adler32.sum()
+    };
+
+    assert_eq!(flate2_adler32, libdeflate_adler32);
+}
+
+#[test]
+fn test_use_adler32_convenience_method_returns_same_adler32_as_adler32_crate() {
+    // This assumes that adler32 crate implementation returns a
+    // correct value, which is a pretty safe assumption.
+
+    let input_data = read_fixture_content();
+
+    let flate2_adler32 = {
+        let mut adler32 = adler32::RollingAdler32::new();
+        adler32.update_buffer(&input_data);
+        adler32.hash()
+    };
+
+    let libdeflate_adler32 = libdeflater::adler32(&input_data);
+
+    assert_eq!(flate2_adler32, libdeflate_adler32);
+}


### PR DESCRIPTION
I was looking for a very performant adler32 implementation that uses SIMD on ARM64, but there was no such implementation in for example simd-adler32 crate. 
I looked up the libdeflate code, and saw that it has a SIMD implementation for ARM64. Knowing that that library is very performance oriented, I tested it using libdeflate-sys and it gave me a huge performance speedup in my project. So I thought, let's contribute back a little bit by making the Adler32 struct and it's methods in this library the same way as CRC32 is done.
