### PR TITLE
Use external/system libdeflate when pkgconfig can find it

### DIFF
--- a/libdeflate-sys/Cargo.toml
+++ b/libdeflate-sys/Cargo.toml
@@ -18,6 +18,7 @@ build = "build.rs"
 
 [build-dependencies]
 cc = "1.0"
+pkg-config = "0.3.9"
 
 [features]
 freestanding = []

--- a/libdeflate-sys/build.rs
+++ b/libdeflate-sys/build.rs
@@ -5,6 +5,15 @@ use std::path::{Path, PathBuf};
 fn main() {
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
+    if pkg_config::Config::new()
+        .print_system_libs(false)
+        .cargo_metadata(true)
+        .probe("libdeflate")
+        .is_ok()
+    {
+        return;
+    }
+
     let mut build = cc::Build::new();
 
     build


### PR DESCRIPTION
This change is needed for packaging in Fedora Linux; it’s offered here in case it’s useful in general.