### PR TITLE
Exclude some files from the published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,13 @@ description = """
 Bindings to libdeflate for DEFLATE (de)compression exposed as non-streaming buffer
 operations. Contains bindings for raw deflate, zlib, and gzip data.
 """
+exclude = [
+    ".git*",
+    ".travis.yml",
+    "bench_data/",
+    "examples/",
+    "scripts/",
+]
 
 [dependencies]
 libdeflate-sys = { version = "1.19.3", path = "libdeflate-sys" }


### PR DESCRIPTION
This was prompted by my need to exclude `scripts/` from the crate source in Fedora’s [`rust-libdeflater`](https://src.fedoraproject.org/rpms/rust-libdeflater) package in order to avoid generating an RPM dependency on the Ruby interpreter. That’s kind of a Fedora-specific thing, but there’s a general improvement to be suggested here.

```
$ cargo publish --dry-run
$ ls -a1 target/package/libdeflater-1.19.3/
.
..
bench_data
benches
Cargo.lock
Cargo.toml
Cargo.toml.orig
.cargo_vcs_info.json
CHANGELOG.md
examples
.gitignore
.gitmodules
LICENSE
README.md
scripts
src
target
tests
.travis.yml
```

Most of these are not needed to build the crate. This PR retains `tests/`, which I selfishly find useful since I package from the published crate and like to run all the tests I can. However, I’m happy to exclude them too, if you prefer.

After the PR:

```
$ cargo publish --dry-run
$ ls -a1 target/package/libdeflater-1.19.3/
.
..
benches
Cargo.lock
Cargo.toml
Cargo.toml.orig
.cargo_vcs_info.json
CHANGELOG.md
LICENSE
README.md
src
target
tests
```

The crate only shrinks slightly (~24 kB to ~22 kB, ~19k without `tests/`), but this still seems worthwhile.