### PR TITLE
Update libdeflate to v1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.0]
+
+- Updated libdeflate to v1.22
+
 ## [1.21.0]
 
 - Updated libdeflate to v1.21 (#37, thanks @musicinmybrain)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdeflater"
-version = "1.21.0"
+version = "1.22.0"
 authors = ["Adam Kewley <contact@adamkewley.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ exclude = [
 ]
 
 [dependencies]
-libdeflate-sys = { version = "1.21.0", path = "libdeflate-sys" }
+libdeflate-sys = { version = "1.22.0", path = "libdeflate-sys" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Documentation](https://docs.rs/libdeflater/badge.svg)](https://docs.rs/libdeflater)
 
 ```
-libdeflater = "1.21.0"
+libdeflater = "1.22.0"
 ```
 
 `libdeflater` is a thin wrapper library around [libdeflate](https://github.com/ebiggers/libdeflate). Libdeflate 

--- a/libdeflate-sys/Cargo.toml
+++ b/libdeflate-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdeflate-sys"
-version = "1.21.0"
+version = "1.22.0"
 authors = ["Adam Kewley <contact@adamkewley.com>"]
 links = "libdeflate"
 edition = "2018"

--- a/libdeflate-sys/build.rs
+++ b/libdeflate-sys/build.rs
@@ -9,7 +9,7 @@ fn main() {
     if pkg_config::Config::new()
         .print_system_libs(false)
         .cargo_metadata(true)
-        .exactly_version("1.21")
+        .exactly_version("1.22")
         .probe("libdeflate")
         .is_ok()
     {


### PR DESCRIPTION
Another libdeflate, another PR!

This imitates https://github.com/adamkewley/libdeflater/pull/37.

The changes in `libdeflate` are basically just workarounds for toolchain issues: https://github.com/ebiggers/libdeflate/compare/v1.21...v1.22