### PR TITLE
Remove a redundant `.clone()` from an example

### DIFF
--- a/examples/gz_compress.rs
+++ b/examples/gz_compress.rs
@@ -5,7 +5,7 @@ use libdeflater::{Compressor, CompressionLvl};
 
 fn main() {
     let str_to_compress = "hello\n";
-    let str_bytes = str_to_compress.as_bytes().clone();
+    let str_bytes = str_to_compress.as_bytes();
 
     let compressed_data = {
         let mut compressor = Compressor::new(CompressionLvl::default());


### PR DESCRIPTION
With `rustc` 1.83.0,

```
warning: call to `.clone()` on a reference in this situation does nothing
 --> examples/gz_compress.rs:8:47
  |
8 |     let str_bytes = str_to_compress.as_bytes().clone();
  |                                               ^^^^^^^^ help: remove this redundant call
  |
  = note: the type `[u8]` does not implement `Clone`, so calling `clone` on `&[u8]` copies the reference, which does not do anything and can be removed
  = note: `#[warn(noop_method_call)]` on by default
```

This PR implements that suggestion, resolving the warning.