### PR TITLE
Update libdeflate to v1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.0]
+
+- Updated libdeflate to v1.23
+
 ## [1.22.0]
 
 - Updated libdeflate to v1.22 (#38, thanks @musicinmybrain)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdeflater"
-version = "1.22.0"
+version = "1.23.0"
 authors = ["Adam Kewley <contact@adamkewley.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ exclude = [
 ]
 
 [dependencies]
-libdeflate-sys = { version = "1.22.0", path = "libdeflate-sys" }
+libdeflate-sys = { version = "1.23.0", path = "libdeflate-sys" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Documentation](https://docs.rs/libdeflater/badge.svg)](https://docs.rs/libdeflater)
 
 ```
-libdeflater = "1.22.0"
+libdeflater = "1.23.0"
 ```
 
 `libdeflater` is a thin wrapper library around [libdeflate](https://github.com/ebiggers/libdeflate). Libdeflate 

--- a/libdeflate-sys/Cargo.toml
+++ b/libdeflate-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdeflate-sys"
-version = "1.22.0"
+version = "1.23.0"
 authors = ["Adam Kewley <contact@adamkewley.com>"]
 links = "libdeflate"
 edition = "2018"

--- a/libdeflate-sys/build.rs
+++ b/libdeflate-sys/build.rs
@@ -9,7 +9,7 @@ fn main() {
     if pkg_config::Config::new()
         .print_system_libs(false)
         .cargo_metadata(true)
-        .exactly_version("1.22")
+        .exactly_version("1.23")
         .probe("libdeflate")
         .is_ok()
     {


### PR DESCRIPTION
Following in the footsteps of https://github.com/adamkewley/libdeflater/pull/38 et al., update libdeflate to 1.23. Tested with `cargo test --workspace`.

https://github.com/ebiggers/libdeflate/compare/v1.22...v1.23

```
# libdeflate release notes

## Version 1.23

* Fixed bug introduced in 1.20 where incorrect checksums could be calculated if
  libdeflate was compiled with clang at -O0 and run on a CPU supporting AVX512.

* Fixed bug introduced in 1.20 where incorrect checksums could be calculated in
  rare cases on macOS computers that support AVX512 and are running an older
  version of macOS that contains a bug that corrupts AVX512 registers.  This
  could occur only if code outside libdeflate enabled AVX512 in the thread.

* Fixed build error when using -mno-evex512 with clang 18+ or gcc 14+.

* Increased the minimum CMake version to 3.10.

* Further optimized the x86 CRC code.
```

See also https://github.com/adamkewley/libdeflater/pull/39, which isn’t related to the `libdeflate` upgrade, but which you might choose to deal with in the same release.