### PR TITLE
use per-{de,}compressor malloc/free, to avoid needing to mess with global state for use_rust_alloc

### DIFF
--- a/libdeflate-sys/src/lib.rs
+++ b/libdeflate-sys/src/lib.rs
@@ -143,6 +143,22 @@ mod tests {
     }
 
     #[test]
+    fn can_make_decompressor_with_null_malloc_free() {
+        unsafe {
+            let options = libdeflate_options {
+                sizeof_options: std::mem::size_of::<libdeflate_options>(),
+                malloc_func: None,
+                free_func: None,
+            };
+            let ptr = libdeflate_alloc_decompressor_ex(&options);
+
+            assert!(!ptr.is_null());
+
+            libdeflate_free_decompressor(ptr);
+        }
+    }
+
+    #[test]
     fn making_compressor_with_negative_compression_lvl_fails() {
         unsafe {
             let ptr = libdeflate_alloc_compressor(-1);

--- a/libdeflate-sys/src/lib.rs
+++ b/libdeflate-sys/src/lib.rs
@@ -12,7 +12,7 @@ pub const libdeflate_result_LIBDEFLATE_SUCCESS: libdeflate_result = 0;
 pub const libdeflate_result_LIBDEFLATE_BAD_DATA: libdeflate_result = 1;
 pub const libdeflate_result_LIBDEFLATE_SHORT_OUTPUT: libdeflate_result = 2;
 pub const libdeflate_result_LIBDEFLATE_INSUFFICIENT_SPACE: libdeflate_result = 3;
-pub type libdeflate_result = u32 ;
+pub type libdeflate_result = ::std::os::raw::c_uint;
 
 extern "C" {
     pub fn libdeflate_alloc_decompressor() -> *mut libdeflate_decompressor;

--- a/libdeflate-sys/src/lib.rs
+++ b/libdeflate-sys/src/lib.rs
@@ -34,6 +34,14 @@ extern "C" {
                                       out_nbytes_avail: usize,
                                       actual_out_nbytes_ret: *mut usize) -> libdeflate_result;
 
+    pub fn libdeflate_gzip_decompress_ex(decompressor: *mut libdeflate_decompressor,
+                                         in_: *const ::std::os::raw::c_void,
+                                         in_nbytes: usize,
+                                         out: *mut ::std::os::raw::c_void,
+                                         out_nbytes_avail: usize,
+                                         actual_in_nbytes_ret: *mut usize,
+                                         actual_out_nbytes_ret: *mut usize) -> libdeflate_result;
+
     pub fn libdeflate_zlib_decompress(decompressor: *mut libdeflate_decompressor,
                                       in_: *const ::std::os::raw::c_void,
                                       in_nbytes: usize,
@@ -41,12 +49,28 @@ extern "C" {
                                       out_nbytes_avail: usize,
                                       actual_out_nbytes_ret: *mut usize) -> libdeflate_result;
 
+    pub fn libdeflate_zlib_decompress_ex(decompressor: *mut libdeflate_decompressor,
+                                         in_: *const ::std::os::raw::c_void,
+                                         in_nbytes: usize,
+                                         out: *mut ::std::os::raw::c_void,
+                                         out_nbytes_avail: usize,
+                                         actual_in_nbytes_ret: *mut usize,
+                                         actual_out_nbytes_ret: *mut usize) -> libdeflate_result;
+
     pub fn libdeflate_deflate_decompress(decompressor: *mut libdeflate_decompressor,
                                          in_: *const ::std::os::raw::c_void,
                                          in_nbytes: usize,
                                          out: *mut ::std::os::raw::c_void,
                                          out_nbytes_avail: usize,
                                          actual_out_nbytes_ret: *mut usize) -> libdeflate_result;
+    
+    pub fn libdeflate_deflate_decompress_ex(decompressor: *mut libdeflate_decompressor, 
+                                            in_: *const ::std::os::raw::c_void,
+                                            in_nbytes: usize,
+                                            out: *mut ::std::os::raw::c_void,
+                                            out_nbytes_avail: usize,
+                                            actual_in_nbytes_ret: *mut usize,
+                                            actual_out_nbytes_ret: *mut usize) -> libdeflate_result;
 
     pub fn libdeflate_alloc_compressor(compression_level: ::std::os::raw::c_int) -> *mut libdeflate_compressor;
     

--- a/libdeflate-sys/src/lib.rs
+++ b/libdeflate-sys/src/lib.rs
@@ -8,6 +8,14 @@
 pub struct libdeflate_compressor { _unused : [ u8 ; 0 ] , }
 #[repr(C)]
 pub struct libdeflate_decompressor { _unused : [ u8 ; 0 ] , }
+
+#[repr(C)]
+pub struct libdeflate_options {
+    pub sizeof_options: usize,
+    pub malloc_func: Option<unsafe extern "C" fn(arg1: usize) -> *mut ::std::os::raw::c_void>,
+    pub free_func: Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
+}
+
 pub const libdeflate_result_LIBDEFLATE_SUCCESS: libdeflate_result = 0;
 pub const libdeflate_result_LIBDEFLATE_BAD_DATA: libdeflate_result = 1;
 pub const libdeflate_result_LIBDEFLATE_SHORT_OUTPUT: libdeflate_result = 2;
@@ -16,6 +24,7 @@ pub type libdeflate_result = ::std::os::raw::c_uint;
 
 extern "C" {
     pub fn libdeflate_alloc_decompressor() -> *mut libdeflate_decompressor;
+    pub fn libdeflate_alloc_decompressor_ex(options: *const libdeflate_options) -> *mut libdeflate_decompressor;
     pub fn libdeflate_free_decompressor(decompressor: *mut libdeflate_decompressor);
 
     pub fn libdeflate_gzip_decompress(decompressor: *mut libdeflate_decompressor,
@@ -40,6 +49,9 @@ extern "C" {
                                          actual_out_nbytes_ret: *mut usize) -> libdeflate_result;
 
     pub fn libdeflate_alloc_compressor(compression_level: ::std::os::raw::c_int) -> *mut libdeflate_compressor;
+    
+    pub fn libdeflate_alloc_compressor_ex(compression_level: ::std::ffi::c_int,
+                                          options: *const libdeflate_options) -> *mut libdeflate_compressor;
 
     pub fn libdeflate_deflate_compress_bound(compressor: *mut libdeflate_compressor,
                                              in_nbytes: usize) -> usize;

--- a/src/malloc_wrapper.rs
+++ b/src/malloc_wrapper.rs
@@ -22,7 +22,7 @@
 //! At this point we can read `size` back and call the Rust `dealloc`
 //! for the whole allocated chunk.
 
-use libdeflate_sys::libdeflate_set_memory_allocator;
+use libdeflate_sys::libdeflate_options;
 use std::alloc::*;
 use std::ffi::c_void;
 use std::mem::{align_of, size_of};
@@ -43,7 +43,8 @@ unsafe extern "C" fn free(data_ptr: *mut c_void) {
     dealloc(size_and_data_ptr as _, layout_for(size))
 }
 
-pub unsafe fn init_allocator() {
-    static INIT: std::sync::Once = std::sync::Once::new();
-    INIT.call_once(|| libdeflate_set_memory_allocator(malloc, free))
-}
+pub static OPTIONS: libdeflate_options = libdeflate_options {
+    sizeof_options: size_of::<libdeflate_options>(),
+    malloc_func: Some(malloc),
+    free_func: Some(free),
+};


### PR DESCRIPTION
This avoids the need to try to set a global malloc/free function for all of libdeflate, instead, configure the malloc/free function for every compressor/decompressor created in rust.

This also includes the updates to the bindings:

* Add `libdeflate_options`, `libdeflate_alloc_decompressor_ex` and `libdeflate_alloc_compressor_ex`, required for configuring per-object malloc/free functions.
* Add additional missing bindings: `libdeflate_gzip_decompress_ex`, `libdeflate_zlib_decompress_ex`, and `libdeflate_deflate_decompress_ex`, which libdeflate provides to allow discovering how much of the input was consumed
* Correct the type of `libdeflate_result` from `u32` to `c_uint`
  * This is _technically_ a breaking change. However, on any relevant system, these will be the same, but in the case where they are different, c_uint is correct.