### PR TITLE
Update libdeflate to v1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming Release]
 
+## [1.24.0]
+
+- Updated libdeflate to v1.24
+
 ## [1.23.1]
 
 - Changed `Compressor`/`Decompressor` functions to accept a `NonNull<T>` rather
@@ -27,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CompressionLvl`-related functions (e.g. `CompressionLevel::fastest()`),
   `Crc::new`, `Crc::sum`, `Adler32::new`, and `Adler32::sum` are now `const`
   (#46, thanks @Dr-Emann).
-
 
 ## [1.23.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdeflater"
-version = "1.23.1"
+version = "1.24.0"
 authors = ["Adam Kewley <contact@adamkewley.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ exclude = [
 ]
 
 [dependencies]
-libdeflate-sys = { version = "1.23.1", path = "libdeflate-sys" }
+libdeflate-sys = { version = "1.24.0", path = "libdeflate-sys" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Documentation](https://docs.rs/libdeflater/badge.svg)](https://docs.rs/libdeflater)
 
 ```
-libdeflater = "1.23.1"
+libdeflater = "1.24.0"
 ```
 
 `libdeflater` is a thin wrapper library around [libdeflate](https://github.com/ebiggers/libdeflate). Libdeflate 

--- a/libdeflate-sys/Cargo.toml
+++ b/libdeflate-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdeflate-sys"
-version = "1.23.1"
+version = "1.24.0"
 authors = ["Adam Kewley <contact@adamkewley.com>"]
 links = "libdeflate"
 edition = "2018"

--- a/libdeflate-sys/build.rs
+++ b/libdeflate-sys/build.rs
@@ -9,7 +9,7 @@ fn main() {
     if pkg_config::Config::new()
         .print_system_libs(false)
         .cargo_metadata(true)
-        .exactly_version("1.23")
+        .exactly_version("1.24")
         .probe("libdeflate")
         .is_ok()
     {


### PR DESCRIPTION
Another `libdeflate` update, like https://github.com/adamkewley/libdeflater/pull/40. Tested with `cargo test --workspace`.

https://github.com/ebiggers/libdeflate/compare/v1.23...v1.24

```
# libdeflate release notes

## Version 1.24

* The CMake-based build system now supports Apple Framework builds.
* libdeflate now builds for Windows ARM64EC.
* Made another small optimization to the x86 and ARM CRC32 code.
* Fixed a compiler warning on certain platforms (issue #416).
```